### PR TITLE
MatchParen and Whitespace

### DIFF
--- a/colors/colibri.vim
+++ b/colors/colibri.vim
@@ -211,7 +211,7 @@ call s:HL('SignColumn', 'active',  'sign_column',      'none')
 call s:HL('FoldColumn', 'active',  'window',           'none')
 call s:HL('Folded',     'comment', 'background_light', 'none')
 
-call s:HL('MatchParen',   'comet', 'silver', '')
+call s:HL('MatchParen',   '', 'background_light', 'bold')
 "call s:HL('MatchParen',   'background_light', 'lavender', '')
 
 call s:HL('StatusLine',   'background_dark', 'active',           '')

--- a/colors/colibri.vim
+++ b/colors/colibri.vim
@@ -211,7 +211,7 @@ call s:HL('SignColumn', 'active',  'sign_column',      'none')
 call s:HL('FoldColumn', 'active',  'window',           'none')
 call s:HL('Folded',     'comment', 'background_light', 'none')
 
-call s:HL('MatchParen',   'background_light', 'honey', '')
+call s:HL('MatchParen',   'comet', 'silver', '')
 "call s:HL('MatchParen',   'background_light', 'lavender', '')
 
 call s:HL('StatusLine',   'background_dark', 'active',           '')

--- a/colors/colibri.vim
+++ b/colors/colibri.vim
@@ -241,7 +241,7 @@ call s:HL('NonText', 'window', '', 'none')
 let s:colibri.neon = ["#2CF2F1", 0] " rotated diff_red hue until cyan
 " Special keys, e.g. some of the chars in 'listchars'. See ':h listchars'.
 call s:HL('SpecialKey', 'neon', '', 'none')
-" neovim: Whitespace
+hi! link Whitespace SpecialKey
 
 " - Diffs
 call s:HL('DiffAdd',     'diff_green', 'background_light', 'bold')


### PR DESCRIPTION
I had an issue with the existing MatchParen highlighting: my cursor would disappear on the first paren, and the eye would then immediately jump to the highlighted/matched paren. Right now the matched one is made bold whereas the first one is just untouched. If you don't like that, maybe a color could be chosen that are is `background_light`?

Additionally I linked `Whitespace` to `SpecialKey`. Without that, e.g., trailing spaces are almost invisible and when the cursor enters e.g., trailing spaces it too is pretty much gone.